### PR TITLE
Fix for issue http://evgeny-goldin.org/youtrack/issue/pl-694

### DIFF
--- a/maven-common/src/main/groovy/com/github/goldin/plugins/common/ConversionUtils.groovy
+++ b/maven-common/src/main/groovy/com/github/goldin/plugins/common/ConversionUtils.groovy
@@ -37,7 +37,7 @@ final class ConversionUtils
                 scope ?: 'compile',
                 type,
                 classifier,
-                new org.apache.maven.artifact.handler.DefaultArtifactHandler(),
+                new org.apache.maven.artifact.handler.DefaultArtifactHandler(type),
                 optional )
 
         if ( file ) { mavenArtifact.file = GMojoUtils.verifyBean().file( file ) }


### PR DESCRIPTION
When creating new maven artifact in maven-plugins/maven-common/src/main/groovy/com/github/goldin/plugins/common/ConversionUtils.groovy toMavenArtifact(), DefaultArtifactHandler is created with correct 'type' parameter to enable maven-war-plugin recognize correct artifact file extension.
