### PR TITLE
empty job.node not working with hudson 3.0

### DIFF
--- a/jenkins-maven-plugin/src/main/groovy/com/github/goldin/plugins/jenkins/markup/ConfigMarkup.groovy
+++ b/jenkins-maven-plugin/src/main/groovy/com/github/goldin/plugins/jenkins/markup/ConfigMarkup.groovy
@@ -90,7 +90,7 @@ class ConfigMarkup extends Markup
                 addScm()
                 add( 'quietPeriod',           job.quietPeriod )
                 add( 'scmCheckoutRetryCount', job.scmCheckoutRetryCount )
-                assignedNode( job.node ?: '' )
+                if(job.node) { assignedNode(job.node) }
                 canRoam( job.node ? false : true )
                 disabled( job.disabled )
                 blockBuildWhenDownstreamBuilding( job.blockBuildWhenDownstreamBuilding )


### PR DESCRIPTION
An empty assginedNode element confuses hudson 3.0, so he set the check
mark for "Restrict where this job can be run" and ignores canRoam. But
without a value for the node the job cannot start.
