### PR TITLE
ivy-maven-plugin: Support Transitive Dependencies

### DIFF
--- a/ivy-maven-plugin/src/main/groovy/com/github/goldin/plugins/ivy/IvyArtifactResolver.groovy
+++ b/ivy-maven-plugin/src/main/groovy/com/github/goldin/plugins/ivy/IvyArtifactResolver.groovy
@@ -45,7 +45,7 @@ class IvyArtifactResolver implements ArtifactResolver {
         final revision     = a.version
         final extension    = a.extension
         // Artifact may have no "file" set if resolution fails and helper's "failOnError" is "false"
-        final artifact     = ivyHelper.resolve( organisation, name, revision, extension, pattern )
+        final artifact     = ivyHelper.resolve( organisation, name, revision, extension, pattern, false ).first()
         final result       = new ArtifactResult( request )                                  // org.sonatype.aether.resolution.ArtifactResult
         result.artifact    = new DefaultArtifact( organisation, name, extension, revision ) // org.sonatype.aether.util.artifact.DefaultArtifact
         if ( artifact.file )

--- a/ivy-maven-plugin/src/main/groovy/com/github/goldin/plugins/ivy/IvyMojo.groovy
+++ b/ivy-maven-plugin/src/main/groovy/com/github/goldin/plugins/ivy/IvyMojo.groovy
@@ -79,6 +79,11 @@ class IvyMojo extends BaseGroovyMojo
     @Parameter ( required = false )
     private boolean failOnError = true
 
+    /**
+     * Should we include transitive dependencies?
+     */
+    @Parameter ( required = false )
+    private boolean transitive = false
 
     @Override
     @Requires({ this.ivyconf })
@@ -177,17 +182,17 @@ class IvyMojo extends BaseGroovyMojo
      * @return artifacts resolved
      */
     @Requires({ helper && dependencies })
-    @Ensures({ result && ( result.size() == dependencies.size()) })
+    @Ensures({ result && ( transitive || result.size() == dependencies.size()) })
     List<Artifact> resolveMavenDependencies ( IvyHelper helper, ArtifactItem[] dependencies )
     {
-        dependencies.collect {
+        dependencies.collectMany {
             ArtifactItem d ->
 
             d.groupId.startsWith( IVY_PREFIX ) ?
-                helper.resolve(                    d.groupId, d.artifactId, d.version,     d.type, d.classifier ) :
-                downloadArtifact( toMavenArtifact( d.groupId, d.artifactId, d.version, '', d.type, d.classifier, false ),
+                helper.resolve(                     d.groupId, d.artifactId, d.version,     d.type, d.classifier, transitive ) :
+                [downloadArtifact( toMavenArtifact( d.groupId, d.artifactId, d.version, '', d.type, d.classifier, false      ),
                                   logVerbosely(),
-                                  failOnError )
+                                  failOnError )]
         }
     }
 }


### PR DESCRIPTION
This allows you to add all the transitive dependencies of an ivy artifact added to your build by the ivy-maven-plugin.
